### PR TITLE
Add support for zOS

### DIFF
--- a/userdirs/app_stub.go
+++ b/userdirs/app_stub.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows,!darwin,!aix,!dragonfly,!freebsd,!netbsd,!openbsd,!solaris
+// +build !linux,!windows,!darwin,!aix,!dragonfly,!freebsd,!netbsd,!openbsd,!solaris,!zos
 
 // The above build constraint must contain the negation of all of the build
 // constraints found in the other app_*.go files, to catch any other OS

--- a/userdirs/app_unix.go
+++ b/userdirs/app_unix.go
@@ -1,4 +1,4 @@
-// +build linux aix dragonfly freebsd netbsd openbsd solaris
+// +build linux aix dragonfly freebsd netbsd openbsd solaris zos
 
 package userdirs
 


### PR DESCRIPTION
Hi,

Thank you for building cool stuff!

zOS is an IBM Z (mainframe) operating system.
This PR adds the appropriate builds tags to support it.

Tests pass and look like this:
```go
go: downloading github.com/google/go-cmp v0.3.0
?   	github.com/apparentlymart/go-userdirs/internal/unix	[no test files]
?   	github.com/apparentlymart/go-userdirs/macosbase	[no test files]
=== RUN   TestDirsNewPath
=== RUN   TestDirsNewPath/NewConfigPath
=== RUN   TestDirsNewPath/NewDataPath
=== RUN   TestDirsNewPath/CachePath
--- PASS: TestDirsNewPath (0.00s)
    --- PASS: TestDirsNewPath/NewConfigPath (0.00s)
    --- PASS: TestDirsNewPath/NewDataPath (0.00s)
    --- PASS: TestDirsNewPath/CachePath (0.00s)
=== RUN   TestDirsFindConfigFiles
=== RUN   TestDirsFindConfigFiles/both
=== RUN   TestDirsFindConfigFiles/only_one
=== RUN   TestDirsFindConfigFiles/none
--- PASS: TestDirsFindConfigFiles (0.00s)
    --- PASS: TestDirsFindConfigFiles/both (0.00s)
    --- PASS: TestDirsFindConfigFiles/only_one (0.00s)
    --- PASS: TestDirsFindConfigFiles/none (0.00s)
=== RUN   TestDirsFindDataFiles
=== RUN   TestDirsFindDataFiles/both
=== RUN   TestDirsFindDataFiles/none
--- PASS: TestDirsFindDataFiles (0.00s)
    --- PASS: TestDirsFindDataFiles/both (0.00s)
    --- PASS: TestDirsFindDataFiles/none (0.00s)
=== RUN   TestDirsGlobConfigFiles
=== RUN   TestDirsGlobConfigFiles/all
=== RUN   TestDirsGlobConfigFiles/none
--- PASS: TestDirsGlobConfigFiles (0.00s)
    --- PASS: TestDirsGlobConfigFiles/all (0.00s)
    --- PASS: TestDirsGlobConfigFiles/none (0.00s)
=== RUN   TestDirsGlobDataFiles
=== RUN   TestDirsGlobDataFiles/all
=== RUN   TestDirsGlobDataFiles/none
--- PASS: TestDirsGlobDataFiles (0.00s)
    --- PASS: TestDirsGlobDataFiles/all (0.00s)
    --- PASS: TestDirsGlobDataFiles/none (0.00s)
PASS
ok  	github.com/apparentlymart/go-userdirs/userdirs	0.442s
?   	github.com/apparentlymart/go-userdirs/windowsbase	[no test files]
?   	github.com/apparentlymart/go-userdirs/xdgbase	[no test files]
```